### PR TITLE
feat: Implementar función para envolver regalos en texto, reto 03

### DIFF
--- a/js-adventjs-2025/reto-03/main.js
+++ b/js-adventjs-2025/reto-03/main.js
@@ -1,0 +1,72 @@
+// En el taller de Santa hay un elfo becario que está aprendiendo a envolver regalos 🎁.
+
+// Le han pedido que envuelva cajas usando solo texto… y lo hace más o menos bien.
+
+// Le pasan dos parámetros:
+
+// size: el tamaño del regalo cuadrado
+// symbol: el carácter que el elfo usa para hacer el borde (cuando no se equivoca 😅)
+// El regalo debe cumplir:
+
+// Debe ser un cuadrado de size x size.
+// El interior siempre está vacío (lleno de espacios), porque el elfo "aún no sabe dibujar el relleno".
+// Si size < 2, devuelve una cadena vacía: el elfo lo intentó, pero se le perdió el regalo.
+// El resultado final debe ser un string con saltos de línea \n.
+// Sí, es un reto fácil… pero no queremos que despidan al becario. ¿Verdad?
+
+// 🧩 Ejemplos
+const g1 = drawGift(4, '*')
+console.log(g1)
+/*
+ ****
+ *  *
+ *  *
+ ****
+ */
+
+const g2 = drawGift(3, '#')
+console.log(g2)
+/*
+###
+# #
+###
+*/
+
+const g3 = drawGift(2, '-')
+console.log(g3)
+/*
+--
+--
+*/
+
+const g4 = drawGift(1, '+')
+console.log(g4)
+// ""  pobre becario…
+
+/**
+ * @param {number} size - The size of the gift
+ * @param {string} symbol - The symbol to draw
+ * @returns {string} The gift drawn
+ */
+function drawGift(size, symbol) {
+  if (size < 2) return '';
+
+  let result = '';
+
+  for (let i = 0; i < size; i++) {
+    // Primera y última fila
+    if (i === 0 || i === size - 1) {
+      result += symbol.repeat(size);
+    } else {
+      // Filas intermedias
+      result += symbol + ' '.repeat(size - 2) + symbol;
+    }
+
+    // Salto de línea excepto en la última fila
+    if (i < size - 1) {
+      result += '\n';
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
Changes:
This pull request introduces a new function, `drawGift`, which generates a square "gift" using a specified symbol and size, following the requirements described in the problem statement. The function includes input validation and is accompanied by example usages and documentation.

New feature: Gift drawing utility

* Added the `drawGift` function in `main.js`, which draws a square of a given size and border symbol, leaving the interior empty, and returns the result as a string. The function returns an empty string for sizes less than 2.
* Included example calls and expected outputs to demonstrate the function's behavior for various input values.
* Provided comprehensive inline documentation and comments to clarify the implementation and requirements.

<img width="1661" height="923" alt="image" src="https://github.com/user-attachments/assets/9a01a397-d3e5-4f90-b8e9-99f42f66f408" />
